### PR TITLE
[why] fix [what] create manager API response must return type(error) …

### DIFF
--- a/src/controller/manager.ts
+++ b/src/controller/manager.ts
@@ -30,7 +30,7 @@ export class ManagerController {
     } catch (e) {
       const responsePayload = new ResponsePayload();
       responsePayload.status = HttpStatus.EXPECTATION_FAILED;
-      responsePayload.type = ResponseType.FINISH;
+      responsePayload.type = ResponseType.ERROR;
       responsePayload.message = e.message;
       throw new HttpException(responsePayload, responsePayload.status);
     }


### PR DESCRIPTION
…when exception occurs